### PR TITLE
startup.cmd 未正常读取 conf 配置文件

### DIFF
--- a/hippo4j-server/bin/startup.cmd
+++ b/hippo4j-server/bin/startup.cmd
@@ -22,8 +22,8 @@ set "HIPPO4J_OPTS=%HIPPO4J_OPTS% -jar %BASE_DIR%\target\%SERVER%.jar"
 
 
 rem set hippo4j spring config location
-set "HIPPO4J_CONFIG_OPTS=--spring.config.location=%CUSTOM_SEARCH_LOCATIONS%"
-set "HIPPO4J_CONFIG_OPTS=%HIPPO4J_OPTS% --server.tomcat.basedir=%BASE_DIR%/bin"
+set "HIPPO4J_CONFIG_OPTS=%HIPPO4J_CONFIG_OPTS% --spring.config.location=%CUSTOM_SEARCH_LOCATIONS%"
+set "HIPPO4J_CONFIG_OPTS=%HIPPO4J_CONFIG_OPTS% --server.tomcat.basedir=%BASE_DIR%/bin"
 
 
 rem set hippo4j logback file location


### PR DESCRIPTION
***问题：***
1. 原参数 --spring.config.location 被覆盖
2. %HIPPO4J_OPTS% 参数重复出现


`%HIPPO4J_OPTS% %HIPPO4J_CONFIG_OPTS%` 
***修复前参数：***
```
-Dhippo4j.home=%BASE_DIR% -jar %BASE_DIR%\target\%SERVER%.jar
-Dhippo4j.home=%BASE_DIR% -jar %BASE_DIR%\target\%SERVER%.jar
--server.tomcat.basedir=%BASE_DIR%/bin
```

***修复后参数：***
```
-Dhippo4j.home=%BASE_DIR% -jar %BASE_DIR%\target\%SERVER%.jar
--spring.config.location=%CUSTOM_SEARCH_LOCATIONS%
--server.tomcat.basedir=%BASE_DIR%/bin
```