### PR TITLE
spring-beans版本升级

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <slf4j-api.version>1.7.7</slf4j-api.version>
         <logback.version>1.2.3</logback.version>
         <mybatis-plus.version>3.4.2</mybatis-plus.version>
-        <spring-boot.version>2.3.2.RELEASE</spring-boot.version>
+        <spring-boot.version>2.5.13</spring-boot.version>
         <apollo.version>1.9.1</apollo.version>
 
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>


### PR DESCRIPTION
升级spring-beans版本以解决远程代码执行的bug，org.springframework:spring-beans 升级至 5.2.20.RELEASE 及以上版本 #196